### PR TITLE
Add LocalInformationService for nearby enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ In an era so chock-full of screens and media capturing your attention, Wander se
    
 4. **TourView:**
    - All information provided in audio form is also available in text form within the TourView for later reference.
+## Data Enrichment Pipeline
+
+Wander now includes a `LocalInformationService` that uses MapKit local search to fetch nearby points of interest. Requests are kept to a 500 meter radius and return a name, coordinate, and optional address to enrich the narration.
+
 
 ## Screenshots
 

--- a/Wander/LocalInformationService.swift
+++ b/Wander/LocalInformationService.swift
@@ -1,0 +1,47 @@
+import Foundation
+import CoreLocation
+#if canImport(MapKit)
+import MapKit
+#endif
+
+/// A service responsible for enriching Wander's data by fetching
+/// points of interest near a given coordinate.
+struct PointOfInterest: Identifiable {
+    let id = UUID()
+    let name: String
+    let coordinate: CLLocationCoordinate2D
+    let address: String?
+}
+
+final class LocalInformationService {
+    /// Search radius in meters. The default of 500m keeps requests localized.
+    private let searchRadius: CLLocationDistance = 500
+
+    /// Fetch nearby points of interest for the supplied coordinate.
+    /// - Parameters:
+    ///   - coordinate: The coordinate to search around.
+    ///   - query: Optional query term, defaults to `"landmark"`.
+    /// - Returns: An array of points of interest.
+    @available(iOS 15.0, *)
+    func fetchNearbyPoints(for coordinate: CLLocationCoordinate2D,
+                           query: String? = nil) async throws -> [PointOfInterest] {
+        #if canImport(MapKit)
+        var request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = query ?? "landmark"
+        request.region = MKCoordinateRegion(center: coordinate,
+                                            latitudinalMeters: searchRadius,
+                                            longitudinalMeters: searchRadius)
+        let search = MKLocalSearch(request: request)
+        let response = try await search.start()
+        return response.mapItems.map {
+            PointOfInterest(name: $0.name ?? "Unknown",
+                            coordinate: $0.placemark.coordinate,
+                            address: $0.placemark.title)
+        }
+        #else
+        // MapKit is unavailable on this platform. Returning an empty array
+        // allows the rest of the app to behave deterministically.
+        return []
+        #endif
+    }
+}

--- a/WanderTests/WanderTests.swift
+++ b/WanderTests/WanderTests.swift
@@ -6,12 +6,20 @@
 //
 
 import Testing
+import CoreLocation
 @testable import Wander
 
 struct WanderTests {
 
     @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // Example placeholder test
     }
 
+    @Test func localInformationServiceReturnsEmptyOnLinux() async throws {
+        #if os(Linux)
+        let service = LocalInformationService()
+        let pois = try await service.fetchNearbyPoints(for: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+        #expect(pois.isEmpty)
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- enrich README with details about the data enrichment pipeline
- introduce `LocalInformationService` to look up nearby points of interest
- expand tests with simple check for the service on Linux

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6847179f972c8321830fb595cacf0549